### PR TITLE
Pin and test Poetry version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,8 @@ jobs:
         python-version: [3.8, 3.9]
     env:
       CODECOV_UPLOAD: true
-      POETRY_HOME: /opt/poetry
+      PIPX_VERSION: "0.16.4"
+      POETRY_VERSION: "1.1.11"
       PYPI_PUBLISH: true
     steps:
       - uses: actions/checkout@v2
@@ -37,12 +38,19 @@ jobs:
           path: ~/.cache/pre-commit
           key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
           restore-keys: ${{ runner.os }}-pre-commit-
+      - name: Install pipx for Python ${{ matrix.python-version }}
+        run: python -m pip install "pipx==$PIPX_VERSION"
       - name: Install Poetry
+        run: pipx install "poetry==$POETRY_VERSION"
+      - name: Test Poetry version
         run: |
-          curl -fsS -o install-poetry.py \
-            https://raw.githubusercontent.com/python-poetry/poetry/HEAD/install-poetry.py
-          python install-poetry.py -y
-          echo "$POETRY_HOME/bin" >> $GITHUB_PATH
+          POETRY_VERSION_INSTALLED=$(poetry -V)
+          echo "The POETRY_VERSION environment variable is set to $POETRY_VERSION."
+          echo "The installed Poetry version is $POETRY_VERSION_INSTALLED."
+          case $POETRY_VERSION_INSTALLED in
+          *$POETRY_VERSION*) echo "Poetry version correct." ;;
+          *) echo "Poetry version incorrect." && exit 1 ;;
+          esac
       - name: Install dependencies
         run: poetry install --no-interaction -E all
       - name: Run pre-commit hooks


### PR DESCRIPTION
## Description

Poetry has introduced a number of problematic changes recently. To help buffer against these problematic changes, this PR will implement installation and testing of specific versions of Poetry, rather than the latest version.

## Changes

The following steps will be taken to install Poetry and verify that the correct version is installed:

1. Set the `PIPX_VERSION` and `POETRY_VERSION` environment variables, which will be used to install specific versions of each package
2. Install `pipx` with `pip`, for the appropriate version of Python (`pipx` is included by default in the [GitHub Actions virtual environment](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md), but only for the default Python version, not necessarily the version installed by [actions/setup-python](https://github.com/actions/setup-python))
3. Install Poetry with `pipx`, instead of the _get-poetry.py_ and _install-poetry.py_ install scripts
4. Run a shell test to assert that the Poetry version returned by the `poetry -V` command matches `POETRY_VERSION`

## Related

- br3ndonland/inboard#36
- br3ndonland/inboard#44
- https://github.com/python-poetry/poetry/discussions/4271
- python-poetry/poetry#4429

- [x] I have reviewed the [Guidelines for Contributing](https://github.com/br3ndonland/fastenv/blob/HEAD/.github/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/br3ndonland/fastenv/blob/HEAD/.github/CODE_OF_CONDUCT.md).
