### PR TITLE
Add Python 3.10 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10"]
     env:
       CODECOV_UPLOAD: true
       PIPX_VERSION: "0.16.4"
@@ -59,13 +59,13 @@ jobs:
         run: poetry run pytest --cov-report=xml
       - name: Upload test coverage report to Codecov
         uses: codecov/codecov-action@v2
-        if: env.CODECOV_UPLOAD == 'true' && matrix.python-version == 3.9
+        if: env.CODECOV_UPLOAD == 'true' && matrix.python-version == '3.10'
         with:
           fail_ci_if_error: true
           flags: unit
-      - name: Build Python package with latest Python version and publish to PyPI
+      - name: Build Python package with latest stable Python version and publish to PyPI
         if: >
           env.PYPI_PUBLISH == 'true' &&
-          matrix.python-version == 3.9 &&
+          matrix.python-version == '3.10' &&
           startsWith(github.ref, 'refs/tags/')
         run: poetry publish --build -u __token__ -p ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
## Description

This PR will add [Python 3.10](https://docs.python.org/3/whatsnew/3.10.html) support to fastenv.

## Changes

### GitHub Actions

- [x] Update GitHub Actions workflow to stable Python 3.10 when it is released
  - [What's new in Python 3.10](https://docs.python.org/3/whatsnew/3.10.html)
  - [actions/python-versions 3.10.0](https://github.com/actions/python-versions/releases/tag/3.10.0-117470)
  - actions/setup-python#249
- [x] Update GitHub Actions Python version syntax to enclose version numbers in quotes
  - Python versions must now be quoted in YAML. `3.10` (without quotes) is interpreted as a float and becomes `3.1`, so `"3.10"` must be used instead.
  - https://github.com/actions/setup-python/issues/249#issuecomment-934299359
  - https://dev.to/hugovk/the-python-3-1-problem-85g

### Poetry

- [x] Ensure Python 3.10 classifier is included with Poetry package builds: fixed as of Poetry 1.1.11 (python-poetry/poetry#4581)

## Related

- br3ndonland/inboard#36
- actions/setup-python#249
- python-poetry/poetry#4581

- [x] I have reviewed the [Guidelines for Contributing](https://github.com/br3ndonland/fastenv/blob/HEAD/.github/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/br3ndonland/fastenv/blob/HEAD/.github/CODE_OF_CONDUCT.md).
