### PR TITLE
Add support for Cloudflare R2 object storage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,9 @@ jobs:
           BACKBLAZE_B2_BUCKET_HOST: ${{ secrets.BACKBLAZE_B2_BUCKET_HOST }}
           BACKBLAZE_B2_BUCKET_REGION: ${{ secrets.BACKBLAZE_B2_BUCKET_REGION }}
           BACKBLAZE_B2_SECRET_KEY_FASTENV: ${{ secrets.BACKBLAZE_B2_SECRET_KEY_FASTENV }}
+          CLOUDFLARE_R2_ACCESS_KEY_FASTENV: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_FASTENV }}
+          CLOUDFLARE_R2_BUCKET_HOST: ${{ secrets.CLOUDFLARE_R2_BUCKET_HOST }}
+          CLOUDFLARE_R2_SECRET_KEY_FASTENV: ${{ secrets.CLOUDFLARE_R2_SECRET_KEY_FASTENV }}
       - name: Enforce test coverage
         run: hatch run ${{ env.HATCH_ENV }}:coverage report
       - name: Build Python package

--- a/docs/cloud-object-storage.md
+++ b/docs/cloud-object-storage.md
@@ -333,8 +333,8 @@ Here's an example of how this could be implemented.
 ### AWS S3
 
 -   Pricing
-    -   \$23/TB/month for storage
-    -   \$90/TB/month outbound (also called download or egress), with further complex and expensive egress fees
+    -   $23/TB/month for storage
+    -   $90/TB/month outbound (also called download or egress), with further complex and expensive egress fees
     -   See the [Backblaze B2 pricing page](https://www.backblaze.com/b2/cloud-storage-pricing.html) for comparisons
     -   See [Backblaze Blog 2021-12-03: Why the world needs lower egress fees](https://www.backblaze.com/blog/why-the-world-needs-lower-egress-fees/) and [Cloudflare Blog 2021-07-23: AWS's egregious egress](https://blog.cloudflare.com/aws-egregious-egress/) for criticisms
 -   Identity and Access Management (IAM):
@@ -355,7 +355,7 @@ Here's an example of how this could be implemented.
 ### Backblaze B2
 
 -   [Pricing](https://www.backblaze.com/b2/cloud-storage-pricing.html):
-    -   \$6/TB/month for storage (about 1/4 the price of S3)
+    -   $6/TB/month for storage (about 1/4 the price of S3)
     -   Outbound (also called download or egress) data transfer fees are 1/4 the price of S3
     -   See [Backblaze Blog 2021-12-03: Why the world needs lower egress fees](https://www.backblaze.com/blog/why-the-world-needs-lower-egress-fees/)
 -   [S3-compatible API](https://www.backblaze.com/b2/docs/s3_compatible_api.html)\*
@@ -377,7 +377,7 @@ Here's an example of how this could be implemented.
 ### Cloudflare R2
 
 -   [Pricing](https://developers.cloudflare.com/r2/platform/pricing/)
-    -   \$15/TB/month for storage (about half the price of AWS S3, but over double the price of Backblaze B2)
+    -   $15/TB/month for storage (about half the price of AWS S3, but over double the price of Backblaze B2)
 -   [S3-compatible API](https://developers.cloudflare.com/r2/platform/s3-compatibility/api/)
 -   URIs
     -   Regions are handled automatically. "When using the S3 API, the region for an R2 bucket is `auto`. For compatibility with tools that do not allow you to specify a region, an empty value and `us-east-1` will alias to the `auto` region."

--- a/docs/cloud-object-storage.md
+++ b/docs/cloud-object-storage.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Dotenv files are commonly kept in [cloud object storage](https://en.wikipedia.org/wiki/Cloud_storage), but environment variable management packages typically don't integrate with object storage clients. Additional logic is therefore required to download the files from object storage prior to loading environment variables. This project offers integration with S3-compatible object storage. [AWS S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html) and [Backblaze B2](https://www.backblaze.com/b2/docs/) are directly supported and tested.
+Dotenv files are commonly kept in [cloud object storage](https://en.wikipedia.org/wiki/Cloud_storage), but environment variable management packages typically don't integrate with object storage clients. Additional logic is therefore required to download the files from object storage prior to loading environment variables. This project offers integration with S3-compatible object storage. [AWS S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html), [Backblaze B2](https://www.backblaze.com/b2/docs/), and [Cloudflare R2](https://developers.cloudflare.com/r2/) are directly supported and tested.
 
 !!!note "Why not Boto3?"
 
@@ -333,6 +333,8 @@ Here's an example of how this could be implemented.
 ### AWS S3
 
 -   Pricing
+    -   \$23/TB/month for storage
+    -   \$90/TB/month outbound (also called download or egress), with further complex and expensive egress fees
     -   See the [Backblaze B2 pricing page](https://www.backblaze.com/b2/cloud-storage-pricing.html) for comparisons
     -   See [Backblaze Blog 2021-12-03: Why the world needs lower egress fees](https://www.backblaze.com/blog/why-the-world-needs-lower-egress-fees/) and [Cloudflare Blog 2021-07-23: AWS's egregious egress](https://blog.cloudflare.com/aws-egregious-egress/) for criticisms
 -   Identity and Access Management (IAM):
@@ -353,7 +355,7 @@ Here's an example of how this could be implemented.
 ### Backblaze B2
 
 -   [Pricing](https://www.backblaze.com/b2/cloud-storage-pricing.html):
-    -   Data storage fees are 1/3 the price of S3
+    -   \$6/TB/month for storage (about 1/4 the price of S3)
     -   Outbound (also called download or egress) data transfer fees are 1/4 the price of S3
     -   See [Backblaze Blog 2021-12-03: Why the world needs lower egress fees](https://www.backblaze.com/blog/why-the-world-needs-lower-egress-fees/)
 -   [S3-compatible API](https://www.backblaze.com/b2/docs/s3_compatible_api.html)\*
@@ -374,10 +376,30 @@ Here's an example of how this could be implemented.
 
 ### Cloudflare R2
 
-_Coming soon!_
-
--   [Cloudflare Blog 2021-07-23: AWS's egregious egress](https://blog.cloudflare.com/aws-egregious-egress/)
--   [Cloudflare Blog 2021-09-28: Announcing Cloudflare R2 Storage](https://blog.cloudflare.com/introducing-r2-object-storage/)
+-   [Pricing](https://developers.cloudflare.com/r2/platform/pricing/)
+    -   \$15/TB/month for storage (about half the price of AWS S3, but over double the price of Backblaze B2)
+-   [S3-compatible API](https://developers.cloudflare.com/r2/platform/s3-compatibility/api/)
+-   URIs
+    -   Regions are handled automatically. "When using the S3 API, the region for an R2 bucket is `auto`. For compatibility with tools that do not allow you to specify a region, an empty value and `us-east-1` will alias to the `auto` region."
+    -   Cloudflare R2 URLs are different from other S3-compatible object storage platforms. The Cloudflare account ID is included in bucket URIs, but the region is not.
+    -   Path style URL: `https://<ACCOUNT_ID>.r2.cloudflarestorage.com/<bucketname>`
+    -   Virtual-hosted-style URL: `https://<BUCKET>.<ACCOUNT_ID>.r2.cloudflarestorage.com` (added [2022-05-16](https://developers.cloudflare.com/r2/platform/changelog/#2022-05-16), also see [cloudflare/cloudflare-docs#6405](https://github.com/cloudflare/cloudflare-docs/pull/6405)), though note that the docs on [using the AWS CLI with R2](https://developers.cloudflare.com/r2/examples/aws/aws-cli/) and and [using Boto3 with R2](https://developers.cloudflare.com/r2/examples/aws/boto3/) still show only path style URLs.
+    -   Presigned URLs are supported
+        -   Added [2022-06-17](https://developers.cloudflare.com/r2/platform/changelog/#2022-06-17)
+        -   There may be CORS limitations on uploads due to lack of ability to set the `Access-Control-Allow-Origin` header ([cloudflare/cloudflare-docs#4455](https://github.com/cloudflare/cloudflare-docs/issues/4455)).
+    -   [Presigned `POST` is not currently supported](https://developers.cloudflare.com/r2/api/s3/presigned-urls/#supported-http-methods).
+-   Identity and Access Management (IAM):
+    -   [Requires generation of a static access key](https://developers.cloudflare.com/r2/data-access/s3-api/tokens/). Does not appear to support temporary credentials from IAM roles (AWS session tokens). Does not appear to support OpenID Connect (OIDC).
+    -   Access keys can be set to either read-only or edit permissions.
+    -   Access keys can be scoped to specific Cloudflare products, Cloudflare accounts, and IP addresses.
+-   Lifecycle policies
+    -   Added [2023-03-16](https://developers.cloudflare.com/r2/reference/changelog/#2023-03-16) ([blog post](https://blog.cloudflare.com/introducing-object-lifecycle-management-for-cloudflare-r2/))
+    -   [Docs](https://developers.cloudflare.com/r2/buckets/object-lifecycles/)
+-   Docs
+    -   [Cloudflare R2 docs](https://developers.cloudflare.com/r2/)
+    -   [Cloudflare Blog 2021-07-23: AWS's egregious egress](https://blog.cloudflare.com/aws-egregious-egress/)
+    -   [Cloudflare Blog 2021-09-28: Announcing Cloudflare R2 Storage](https://blog.cloudflare.com/introducing-r2-object-storage/)
+    -   [Cloudflare Blog 2022-09-21: R2 is now Generally Available](https://blog.cloudflare.com/r2-ga/)
 
 ### DigitalOcean Spaces
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -170,6 +170,9 @@ BACKBLAZE_B2_ACCESS_KEY_FASTENV="paste-here"
  BACKBLAZE_B2_SECRET_KEY_FASTENV="paste-here"
 BACKBLAZE_B2_BUCKET_HOST="paste-here"
 BACKBLAZE_B2_BUCKET_REGION="paste-here"
+CLOUDFLARE_R2_ACCESS_KEY_FASTENV="paste-here"
+ CLOUDFLARE_R2_SECRET_KEY_FASTENV="paste-here"
+CLOUDFLARE_R2_BUCKET_HOST="paste-here"
 
 # get AWS account ID from STS (replace jq with other JSON parser as needed)
 AWS_ACCOUNT_ID=$(aws sts get-caller-identity | jq -r .Account)
@@ -192,6 +195,9 @@ AWS_IAM_ACCESS_KEY_FASTENV=$(aws configure get fastenv.aws_access_key_id) \
   BACKBLAZE_B2_SECRET_KEY_FASTENV=$BACKBLAZE_B2_SECRET_KEY_FASTENV \
   BACKBLAZE_B2_BUCKET_HOST=$BACKBLAZE_B2_BUCKET_HOST \
   BACKBLAZE_B2_BUCKET_REGION=$BACKBLAZE_B2_BUCKET_REGION \
+  CLOUDFLARE_R2_ACCESS_KEY_FASTENV=$CLOUDFLARE_R2_ACCESS_KEY_FASTENV \
+  CLOUDFLARE_R2_SECRET_KEY_FASTENV=$CLOUDFLARE_R2_SECRET_KEY_FASTENV \
+  CLOUDFLARE_R2_BUCKET_HOST=$CLOUDFLARE_R2_BUCKET_HOST \
   hatch run coverage run && coverage report
 ```
 
@@ -247,6 +253,12 @@ The OIDC infrastructure is provisioned with Terraform, using a similar approach 
 A [B2 application key](https://www.backblaze.com/b2/docs/application_keys.html) is stored in GitHub Secrets, along with the corresponding bucket host in "virtual-hosted-style" format (`<bucket-name>.s3.<region-name>.backblazeb2.com`).
 
 See the [Backblaze B2 S3-compatible API docs](https://www.backblaze.com/b2/docs/s3_compatible_api.html) for further info.
+
+### GitHub Actions and Cloudflare R2
+
+A [Cloudflare S3 auth token](https://developers.cloudflare.com/r2/data-access/s3-api/tokens/) (access key) is stored in GitHub Secrets, along with the corresponding bucket host in "virtual-hosted-style" format (`https://<BUCKET>.<ACCOUNT_ID>.r2.cloudflarestorage.com`).
+
+See the [Cloudflare R2 docs](https://developers.cloudflare.com/r2/) for further info.
 
 ## Maintainers
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,6 +58,13 @@ _cloud_params_backblaze_static = CloudParams(
     bucket_host_variable="BACKBLAZE_B2_BUCKET_HOST",
     bucket_region_variable="BACKBLAZE_B2_BUCKET_REGION",
 )
+_cloud_params_cloudflare_static = CloudParams(
+    access_key_variable="CLOUDFLARE_R2_ACCESS_KEY_FASTENV",
+    secret_key_variable="CLOUDFLARE_R2_SECRET_KEY_FASTENV",
+    session_token_variable="",
+    bucket_host_variable="CLOUDFLARE_R2_BUCKET_HOST",
+    bucket_region_variable="auto",
+)
 
 
 @pytest.fixture(
@@ -65,6 +72,7 @@ _cloud_params_backblaze_static = CloudParams(
         _cloud_params_aws_session,
         _cloud_params_aws_static,
         _cloud_params_backblaze_static,
+        _cloud_params_cloudflare_static,
     ),
     scope="session",
 )
@@ -90,7 +98,7 @@ def object_storage_config(
         else request_param.session_token_variable
     )
     bucket_host = os.getenv(request_param.bucket_host_variable)
-    bucket_region = os.getenv(request_param.bucket_region_variable, "us-east-2")
+    bucket_region = os.getenv(request_param.bucket_region_variable)
     if not access_key or not secret_key or session_token is None:  # pragma: no cover
         pytest.skip("Required cloud credentials not present.")
     return fastenv.cloud.object_storage.ObjectStorageConfig(


### PR DESCRIPTION
## Description

Dotenv files are commonly kept in cloud object storage. [fastenv provides an object storage client](https://fastenv.bws.bio/cloud-object-storage) for downloading and uploading dotenv files.

The fastenv object storage client currently supports AWS S3 and Backblaze B2. There are many other object storage platforms with "S3-compatible" APIs, including [Cloudflare R2](https://developers.cloudflare.com/r2/). This PR will implement support for Cloudflare R2.

## Changes

- Handle Cloudflare R2 bucket hosts
  - The fastenv object storage client works with "virtual-hosted-style" URLs, as this is the [preferred format for AWS S3](https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/).
  - Cloudflare R2 "virtual-hosted-style" URLs, like `https://<BUCKET>.<ACCOUNT_ID>.r2.cloudflarestorage.com`, were implemented on [2022-05-16](https://developers.cloudflare.com/r2/platform/changelog/#2022-05-16) (also see [cloudflare/cloudflare-docs#6405](https://github.com/cloudflare/cloudflare-docs/pull/6405)).
- Handle [Cloudflare R2 bucket region `auto`](https://developers.cloudflare.com/r2/api/s3/api/)
- Add Cloudflare R2 credentials to tests
- Skip tests that do uploads with `POST` ([Cloudflare R2 only supports uploads with `PUT`](https://developers.cloudflare.com/r2/api/s3/presigned-urls/))
- Update [object storage docs](https://fastenv.bws.bio/cloud-object-storage) with info on Cloudflare R2

## Related

- https://github.com/br3ndonland/fastenv/pull/8
- https://github.com/br3ndonland/fastenv/pull/25
- [Cloudflare R2](https://developers.cloudflare.com/r2/)