### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     env:
       HATCH_ENV: "ci"
       HATCH_VERSION: "1.9.4"
@@ -91,7 +91,7 @@ jobs:
           *) echo "Incorrect Hatch virtualenv." && exit 1 ;;
           esac
       - name: Test that Git tag version and Python package version match
-        if: github.ref_type == 'tag' && matrix.python-version == '3.11'
+        if: github.ref_type == 'tag' && matrix.python-version == '3.12'
         run: |
           GIT_TAG_VERSION=$GITHUB_REF_NAME
           PACKAGE_VERSION=$(hatch version)
@@ -133,7 +133,7 @@ jobs:
       - name: Publish Python package to PyPI
         if: >
           github.ref_type == 'tag' &&
-          matrix.python-version == '3.11' &&
+          matrix.python-version == '3.12' &&
           needs.setup.outputs.environment-name == 'PyPI'
         uses: pypa/gh-action-pypi-publish@release/v1.8
   changelog:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - uses: github/codeql-action/init@v3
         with:
           languages: python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Topic :: Internet :: WWW/HTTP :: HTTP Servers",
   "Topic :: Software Development :: Libraries :: Application Frameworks",
   "Topic :: System :: Installation/Setup",


### PR DESCRIPTION
## Description

This PR will add [Python 3.12](https://docs.python.org/3/whatsnew/3.12.html) support to fastenv.

## Changes

### Code changes

- Add Python 3.12 classifier to _pyproject.toml_
- Add Python 3.12 to GitHub Actions workflows

### Results

- fastenv will now include a Python 3.12 classifier in its PyPI package
- fastenv will now build and publish its PyPI package using Python 3.12
- fastenv will now run tests with Python 3.12, in addition to 3.8-3.11

## Related

- [x] I have reviewed the [Guidelines for Contributing](https://github.com/br3ndonland/fastenv/blob/develop/.github/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/br3ndonland/fastenv/blob/develop/.github/CODE_OF_CONDUCT.md).

Related projects that have released support for Python 3.12 include:

- AnyIO ([4.0.0 - 2023-08-30](https://github.com/agronholm/anyio/releases/tag/4.0.0))
- Hatch ([1.8.0 - 2023-12-11](https://github.com/pypa/hatch/releases/tag/hatch-v1.8.0))
- HTTPX ([0.25.1 - 2023-11-03](https://github.com/encode/httpx/releases/tag/0.25.1))