### PR TITLE
Add Python 3.14 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     env:
       HATCH_ENV_TYPE_VIRTUAL_PATH: ".venv"
       HATCH_ENV: "ci"
@@ -64,7 +64,7 @@ jobs:
           *) echo "Incorrect Hatch virtualenv." && exit 1 ;;
           esac
       - name: Test that Git tag version and Python package version match
-        if: github.ref_type == 'tag' && matrix.python-version == '3.13'
+        if: github.ref_type == 'tag' && matrix.python-version == '3.14'
         run: |
           GIT_TAG_VERSION=$GITHUB_REF_NAME
           PACKAGE_VERSION=$(hatch version)
@@ -104,7 +104,7 @@ jobs:
       - name: Build Python package
         run: hatch build
       - name: Upload Python package artifacts
-        if: github.ref_type == 'tag' && matrix.python-version == '3.13'
+        if: github.ref_type == 'tag' && matrix.python-version == '3.14'
         uses: actions/upload-artifact@v7
         with:
           if-no-files-found: error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Internet :: WWW/HTTP :: HTTP Servers",
   "Topic :: Software Development :: Libraries :: Application Frameworks",
   "Topic :: System :: Installation/Setup",


### PR DESCRIPTION
## Description

This PR will add [Python 3.14](https://docs.python.org/3/whatsnew/3.14.html) support to fastenv.

## Changes

### Code changes

- Add Python 3.14 classifier to `pyproject.toml`
- Add Python 3.14 to GitHub Actions workflows

### Results

- fastenv will now include a Python 3.14 classifier in its PyPI package
- fastenv will now build and publish its PyPI package using Python 3.14
- fastenv will now run tests with Python 3.14, in addition to 3.10-3.13

## Related

- [x] I have reviewed the [Guidelines for Contributing](https://github.com/br3ndonland/fastenv/blob/HEAD/docs/contributing.md) and the [Code of Conduct](https://github.com/br3ndonland/fastenv/blob/HEAD/.github/CODE_OF_CONDUCT.md).

Related projects that have released support for Python 3.14 include:

- AnyIO ([4.10.0 - 2025-08-04](https://github.com/agronholm/anyio/releases/tag/4.10.0))
- Hatch ([1.15.0 - 2025-10-15](https://github.com/pypa/hatch/releases/tag/hatch-v1.15.0))
- HTTPXYZ ([0.28.2 - 2026-03-24](https://pypi.org/project/httpxyz/0.28.2/))
- pipx ([1.9.0 - 2026-03-17](https://github.com/pypa/pipx/releases/tag/1.9.0))