### PR TITLE
Drop Python 3.10 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     env:
       HATCH_ENV_TYPE_VIRTUAL_PATH: ".venv"
       HATCH_ENV: "ci"

--- a/fastenv/cloud/object_storage.py
+++ b/fastenv/cloud/object_storage.py
@@ -276,7 +276,7 @@ class ObjectStorageClient:
         https://github.com/encode/httpx/discussions/1599
         https://github.com/encode/httpx/releases/tag/0.18.0
         """
-        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        now = datetime.datetime.now(tz=datetime.UTC)
         x_amz_date = now.strftime("%Y%m%dT%H%M%SZ")
         date_stamp = now.strftime("%Y%m%d")
         credential_scope = (
@@ -620,7 +620,7 @@ class ObjectStorageClient:
         For example, either `x-amz-signature` or `X-Amz-Signature` are valid keys.
         All policy condition keys will be normalized to lowercase.
         """
-        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        now = datetime.datetime.now(tz=datetime.UTC)
         x_amz_date = now.strftime("%Y%m%dT%H%M%SZ")
         date_stamp = now.strftime("%Y%m%d")
         expiration_time = now + datetime.timedelta(seconds=expires)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "fastenv"
 description = "Unified environment variable and settings management for FastAPI and beyond."
 readme = "docs/index.md"
-requires-python = ">=3.10,<4"
+requires-python = ">=3.11,<4"
 license = "MIT"
 authors = [{ name = "Brendon Smith", email = "bws@bws.bio" }]
 keywords = ["asgi", "dotenv", "environment variables", "fastapi", "settings"]
@@ -11,7 +11,6 @@ classifiers = [
   "Intended Audience :: Developers",
   "Natural Language :: English",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
@@ -59,7 +58,7 @@ requires = ["hatchling>=1.26.3,<2"]
 build-backend = "hatchling.build"
 
 [tool.basedpyright]
-pythonVersion = "3.10"
+pythonVersion = "3.11"
 reportImplicitOverride = "information"
 
 [tool.coverage.report]

--- a/tests/cloud/test_object_storage.py
+++ b/tests/cloud/test_object_storage.py
@@ -395,7 +395,7 @@ class TestObjectStorageClientUnit:
             config=object_storage_config
         )
         expires = 86400
-        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        now = datetime.datetime.now(tz=datetime.UTC)
         x_amz_date = now.strftime("%Y%m%dT%H%M%SZ")
         date_stamp = now.strftime("%Y%m%d")
         credential_scope = (
@@ -462,7 +462,7 @@ class TestObjectStorageClientUnit:
         object_storage_client = fastenv.cloud.object_storage.ObjectStorageClient(
             config=object_storage_config
         )
-        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        now = datetime.datetime.now(tz=datetime.UTC)
         x_amz_date = now.strftime("%Y%m%dT%H%M%SZ")
         date_stamp = now.strftime("%Y%m%d")
         credential_scope = (
@@ -510,7 +510,7 @@ class TestObjectStorageClientUnit:
         object_storage_client = fastenv.cloud.object_storage.ObjectStorageClient(
             config=object_storage_config
         )
-        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        now = datetime.datetime.now(tz=datetime.UTC)
         date_stamp = now.strftime("%Y%m%d")
         string_to_sign = (
             "AWS4-HMAC-SHA256\n"
@@ -666,7 +666,7 @@ class TestObjectStorageClientUnit:
         object_storage_client = fastenv.cloud.object_storage.ObjectStorageClient(
             config=object_storage_config
         )
-        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        now = datetime.datetime.now(tz=datetime.UTC)
         x_amz_date = now.strftime("%Y%m%dT%H%M%SZ")
         date_stamp = now.strftime("%Y%m%d")
         expiration_time = now + datetime.timedelta(seconds=129600)
@@ -767,7 +767,7 @@ class TestObjectStorageClientUnit:
         object_storage_client = fastenv.cloud.object_storage.ObjectStorageClient(
             config=object_storage_config
         )
-        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        now = datetime.datetime.now(tz=datetime.UTC)
         date_stamp = now.strftime("%Y%m%d")
         base64_encoded_policy = (
             "eyAiZXhwaXJhdGlvbiI6ICIyMDE1LTEyLTMwVDEyOjAwOjAwLjAwMFoiLA0KICAiY29uZGl0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -298,7 +298,7 @@ def object_storage_client_upload_prefix() -> str:
     will be formatted like "2022-01-01-220123-UTC". There is also a random text
     string added, to ensure that each test run has a unique prefix.
     """
-    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    now = datetime.datetime.now(tz=datetime.UTC)
     now_string = now.strftime("%Y-%m-%d-%H%M%S-%Z")
     hex_prefix = secrets.token_hex()[:10]
     return f"uploads/{now_string}-{hex_prefix}"


### PR DESCRIPTION
## Description

Python 3.10 is in security-only maintenance and reaches [end-of-life](https://devguide.python.org/versions/) in October 2026.

## Changes

This PR will:

- Require Python 3.11 or newer.
- Remove Python 3.10 from the GitHub Actions matrix and package classifiers.
- Use `datetime.UTC` now that Python 3.11 is required.

## Related

- [x] I have reviewed the [Guidelines for Contributing](https://github.com/br3ndonland/fastenv/blob/HEAD/docs/contributing.md) and the [Code of Conduct](https://github.com/br3ndonland/fastenv/blob/HEAD/.github/CODE_OF_CONDUCT.md).
- [Python Developer's Guide: Status of Python versions](https://devguide.python.org/versions/)
